### PR TITLE
Added Barangay-API

### DIFF
--- a/content/projects/barangay-api/index.md
+++ b/content/projects/barangay-api/index.md
@@ -1,0 +1,66 @@
+---
+title: Barangay API
+summary: |
+    A containerizable FastAPI application for the list of Philippine regions, 
+    provinces, cities, municipalities, and barangay according to the August 2025 
+    masterlist from Philippine Standard Geographic Code (PSGC) Release.
+
+description: |
+    A containerizable FastAPI application for the list of Philippine regions, 
+    provinces, cities, municipalities, and barangay according to the August 2025 
+    masterlist from Philippine Standard Geographic Code (PSGC) Release.
+
+    This project is a FastAPI wrapper around the 
+    [barangay](https://pypi.org/project/barangay) package, providing a simple and 
+    efficient way to interact with the Philippine Standard Geographic Code (PSGC) data.
+
+    Features include a performant fuzzy-search for barangays (0.02s per match), and
+    traversible REST API endpoints for Philippine administrative areas, and PSGC focused
+    REST API endpoints.
+
+# Project URLs
+repository: https://github.com/bendlikeabamboo/barangay-api
+website: https://barangay-api.hawitsu.xyz/docs
+demo: https://barangay-api.hawitsu.xyz/docs
+
+# Project Details
+license: MIT
+status: stable
+dateAdded: 2025-10-05
+
+# People
+maintainers:
+    - 'manuelb@hawitsu.xyz'
+
+# Categorization
+tags:
+    - barangay
+    - fastapi
+    - python
+    - docker
+    - pandas
+sectors:
+    - DEPDev
+    - Geography
+    - Civic Tech
+featured: False
+
+# Social Impact
+impact: |
+    Performant data integrator (fuzzy matching barangay), simple, up-to-date and
+    consistent geographical hierarchy traversal (useful in forms), and can be used and
+    extended by anyone (MIT License)
+---
+
+A containerizable FastAPI application for the list of Philippine regions, 
+provinces, cities, municipalities, and barangay according to the August 2025 
+masterlist from Philippine Standard Geographic Code (PSGC) Release.
+
+This project is a FastAPI wrapper around the 
+[barangay](https://pypi.org/project/barangay) package, providing a simple and 
+efficient way to interact with the Philippine Standard Geographic Code (PSGC) data.
+
+Features include a performant fuzzy-search for barangays (0.02s per match), and
+traversible REST API endpoints for Philippine administrative areas, and PSGC focused
+REST API endpoints.
+


### PR DESCRIPTION
A containerizable FastAPI application for the list of Philippine regions, provinces, cities, municipalities, and barangay according to the August 2025 master list from Philippine Standard Geographic Code (PSGC) Release.

This project is a FastAPI wrapper around the [barangay](https://pypi.org/project/barangay) package, providing a simple and efficient way to interact with the Philippine Standard Geographic Code (PSGC) data.

Features include a performant fuzzy-search for barangays (0.02s per match), and traversable REST API endpoints for Philippine administrative areas, and PSGC focused REST API endpoints.