### PR TITLE
feat(content): add psgc api

### DIFF
--- a/content/projects/psgc-api/index.md
+++ b/content/projects/psgc-api/index.md
@@ -1,0 +1,18 @@
+---
+title: PSGC API
+summary:  Philippine Standard Geographic Code (PSGC) API written in Rust
+status: beta
+repoUrl: https://github.com/mystique09/psgc-rs
+website: https://api-psgc-production.up.railway.app
+license: MIT
+maintainers: ['benjiebengarcia@gmail.com']
+tags: []
+sectors: ['Technology']
+featured: False
+dateAdded: 2025-10-25
+lastUpdated: 2025-10-25
+---
+
+An over-engineered Rust implementation of the Philippine Standard Geographic Code (PSGC) API. This project serves as a
+rewrite of the original PSGC-API, leveraging Rust's performance and safety features along with modern database
+technologies.


### PR DESCRIPTION
An over-engineered Rust implementation of the Philippine Standard Geographic Code (PSGC) API. This project serves as a rewrite of the original PSGC-API, leveraging Rust's performance and safety features along with modern database technologies.

This was done by @mystique09. Not sure if this is similar to #4 but that PR is written in python and provides a separate python package so I think it's good if both are included anyways.